### PR TITLE
fog occlusion and slider fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs = -Xmx2G
 org.gradle.parallel = true
 org.gradle.caching = true
 
-mod_version = 2.1.1
+mod_version = 2.2.0
 minecraft_version = 1.16.1
 yarn_mappings = 1.16.1-build.22
 loader_version = 0.15.6

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -343,6 +343,20 @@ public class SodiumGameOptionPages {
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build()
                 )
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setName("Show Entity Culling")
+                        .setTooltip("If enabled, Entity Culling will be added to the vanilla menu so it can be toggled while in a world.")
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opts, value) -> opts.speedrun.showEntityCulling = value, opts -> opts.speedrun.showEntityCulling)
+                        .build()
+                )
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setName("Show Fog Occlusion")
+                        .setTooltip("If enabled, Fog Occlusion will be added to the vanilla menu so it can be toggled while in a world.")
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opts, value) -> opts.speedrun.showFogOcclusion = value, opts -> opts.speedrun.showFogOcclusion)
+                        .build()
+                )
                 .build());
         return new OptionPage("Speedrun", ImmutableList.copyOf(groups));
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -49,6 +49,8 @@ public class SodiumGameOptions {
 
     public static class SpeedrunSettings {
         public boolean usePlanarFog = true;
+        public boolean showEntityCulling = true;
+        public boolean showFogOcclusion = true;
     }
 
     private static final Gson GSON = new GsonBuilder()

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/VanillaOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/VanillaOptions.java
@@ -1,7 +1,7 @@
 package me.jellysquid.mods.sodium.client.gui;
 
 import me.jellysquid.mods.sodium.client.gui.vanilla.builders.CycleOptionBuilder;
-import me.jellysquid.mods.sodium.client.gui.vanilla.options.EntityCulling;
+import me.jellysquid.mods.sodium.client.gui.vanilla.options.BooleanCyclingOption;
 import net.minecraft.client.options.Option;
 
 import java.util.HashSet;
@@ -24,12 +24,21 @@ public class VanillaOptions {
         DOUBLE_OPTIONS_RUNNABLE.add(apply);
     }
 
-    public static final Option ENTITY_CULLING = new CycleOptionBuilder<EntityCulling>()
+    public static final Option ENTITY_CULLING = new CycleOptionBuilder<BooleanCyclingOption>()
             .setKey("options.entityCulling")
             .setText("Entity Culling")
-            .setOptions(EntityCulling.values())
-            .setGetter((options) -> EntityCulling.getOption(options.advanced.useEntityCulling))
+            .setOptions(BooleanCyclingOption.values())
+            .setGetter((options) -> BooleanCyclingOption.getOption(options.advanced.useEntityCulling))
             .setSetter((options, value) -> options.advanced.useEntityCulling = value.isEnabled())
-            .setTextGetter(EntityCulling::getText)
+            .setTextGetter(BooleanCyclingOption::getText)
+            .build();
+
+    public static final Option FOG_OCCLUSION = new CycleOptionBuilder<BooleanCyclingOption>()
+            .setKey("options.fogOcclusion")
+            .setText("Fog Occlusion")
+            .setOptions(BooleanCyclingOption.values())
+            .setGetter(options -> BooleanCyclingOption.getOption(options.advanced.useFogOcclusion))
+            .setSetter((options, value) -> options.advanced.useFogOcclusion = value.isEnabled())
+            .setTextGetter(BooleanCyclingOption::getText)
             .build();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/vanilla/options/BooleanCyclingOption.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/vanilla/options/BooleanCyclingOption.java
@@ -3,15 +3,15 @@ package me.jellysquid.mods.sodium.client.gui.vanilla.options;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 
-public enum EntityCulling implements IndexedOption {
-
+public enum BooleanCyclingOption implements IndexedOption {
     ON(0, true, "options.on"),
     OFF(1, false, "options.off");
 
     private final int index;
     private final boolean enabled;
     private final Text text;
-    EntityCulling(int index, boolean enabled, String translationKey){
+
+    BooleanCyclingOption(int index, boolean enabled, String translationKey) {
         this.index = index;
         this.enabled = enabled;
         this.text = new TranslatableText(translationKey);
@@ -30,8 +30,8 @@ public enum EntityCulling implements IndexedOption {
         return text;
     }
 
-    public static EntityCulling getOption(boolean value){
-        if(value){
+    public static BooleanCyclingOption getOption(boolean value) {
+        if (value) {
             return ON;
         }
         return OFF;

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
@@ -53,7 +53,6 @@ public class MixinVideoOptionsScreen extends GameOptionsScreen {
     @Redirect(method = "init", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonListWidget;addAll([Lnet/minecraft/client/options/Option;)V"))
     private void optionsSwap(ButtonListWidget list, Option[] old_options){
         list.addAll(OPTIONS);
-        VanillaOptions.clearSettingsChanges();
     }
 
     @Inject(method = "mouseReleased", at = @At("RETURN"))

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
@@ -47,7 +47,8 @@ public class MixinVideoOptionsScreen extends GameOptionsScreen {
             Option.MIPMAP_LEVELS,
             Option.ENTITY_SHADOWS,
             Option.ENTITY_DISTANCE_SCALING,
-            VanillaOptions.ENTITY_CULLING
+            VanillaOptions.ENTITY_CULLING,
+            VanillaOptions.FOG_OCCLUSION
     };
 
     @Redirect(method = "init", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonListWidget;addAll([Lnet/minecraft/client/options/Option;)V"))

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.sodium.mixin.features.options;
 
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
 import me.jellysquid.mods.sodium.client.gui.VanillaOptions;
 import me.jellysquid.mods.sodium.client.gui.options.OptionFlag;
@@ -22,6 +23,9 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 @Mixin(VideoOptionsScreen.class)
@@ -31,29 +35,17 @@ public class MixinVideoOptionsScreen extends GameOptionsScreen {
         super(parent, gameOptions, title);
     }
 
-    private static final Option[] OPTIONS = {
-            Option.GRAPHICS,
-            Option.RENDER_DISTANCE,
-            Option.AO,
-            Option.FRAMERATE_LIMIT,
-            Option.VSYNC,
-            Option.VIEW_BOBBING,
-            Option.GUI_SCALE,
-            Option.ATTACK_INDICATOR,
-            Option.GAMMA,
-            Option.CLOUDS,
-            Option.FULLSCREEN,
-            Option.PARTICLES,
-            Option.MIPMAP_LEVELS,
-            Option.ENTITY_SHADOWS,
-            Option.ENTITY_DISTANCE_SCALING,
-            VanillaOptions.ENTITY_CULLING,
-            VanillaOptions.FOG_OCCLUSION
-    };
-
     @Redirect(method = "init", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonListWidget;addAll([Lnet/minecraft/client/options/Option;)V"))
-    private void optionsSwap(ButtonListWidget list, Option[] old_options){
-        list.addAll(OPTIONS);
+    private void optionsSwap(ButtonListWidget list, Option[] old_options) {
+        List<Option> options =  new ArrayList<>(Arrays.asList(old_options));
+        SodiumGameOptions.SpeedrunSettings speedrunSettings = SodiumClientMod.options().speedrun;
+        if (speedrunSettings.showEntityCulling) {
+            options.add(VanillaOptions.ENTITY_CULLING);
+        }
+        if (speedrunSettings.showFogOcclusion) {
+            options.add(VanillaOptions.FOG_OCCLUSION);
+        }
+        list.addAll(options.toArray(new Option[0]));
     }
 
     @Inject(method = "mouseReleased", at = @At("RETURN"))


### PR DESCRIPTION
changes
\- add fog occlusion to vanilla video options screen
\- make the addition of entity culling and fog occlusion options to the vanilla video options screen individually optional

fixes
\- queued setting change is cleared if slider is still held down when fullscreen (re-init)