### PR TITLE
fog occlusion and slider fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,8 @@
 org.gradle.jvmargs = -Xmx2G
 org.gradle.parallel = true
 org.gradle.caching = true
-loom.mixin.useLegacyMixinAp = false
 
-mod_version = 1.2.2
+mod_version = 1.3.0
 minecraft_version = 1.15.2
 yarn_mappings = 1.15.2+build.17
 loader_version = 0.15.6

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -324,6 +324,20 @@ public class SodiumGameOptionPages {
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build()
                 )
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setName("Show Entity Culling")
+                        .setTooltip("If enabled, Entity Culling will be added to the vanilla menu so it can be toggled while in a world.")
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opts, value) -> opts.unofficial.showEntityCulling = value, opts -> opts.unofficial.showEntityCulling)
+                        .build()
+                )
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setName("Show Fog Occlusion")
+                        .setTooltip("If enabled, Fog Occlusion will be added to the vanilla menu so it can be toggled while in a world.")
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opts, value) -> opts.unofficial.showFogOcclusion = value, opts -> opts.unofficial.showFogOcclusion)
+                        .build()
+                )
                 .build());
         return new OptionPage("Unofficial", ImmutableList.copyOf(groups));
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -201,7 +201,6 @@ public class SodiumGameOptionPages {
 
     public static OptionPage advanced() {
         boolean disableBlacklist = SodiumClientMod.options().advanced.disableDriverBlacklist;
-        boolean usePlanarFog = SodiumClientMod.options().unofficial.usePlanarFog;
 
         List<OptionGroup> groups = new ArrayList<>();
 
@@ -319,7 +318,7 @@ public class SodiumGameOptionPages {
                                 "in areas with thick fog such as in the nether. This is vanilla behavior on systems where GL_NV_fog_distance is unavailable, but is not " +
                                 "considered desirable for any reason other than visibility. This option is not included in official releases of Sodium.")
                         .setControl(TickBoxControl::new)
-                        .setBinding((opts, value) -> opts.unofficial.usePlanarFog = value, opts -> opts.unofficial.usePlanarFog)
+                        .setBinding((opts, value) -> opts.speedrun.usePlanarFog = value, opts -> opts.speedrun.usePlanarFog)
                         .setImpact(OptionImpact.MEDIUM)
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build()
@@ -328,17 +327,17 @@ public class SodiumGameOptionPages {
                         .setName("Show Entity Culling")
                         .setTooltip("If enabled, Entity Culling will be added to the vanilla menu so it can be toggled while in a world.")
                         .setControl(TickBoxControl::new)
-                        .setBinding((opts, value) -> opts.unofficial.showEntityCulling = value, opts -> opts.unofficial.showEntityCulling)
+                        .setBinding((opts, value) -> opts.speedrun.showEntityCulling = value, opts -> opts.speedrun.showEntityCulling)
                         .build()
                 )
                 .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
                         .setName("Show Fog Occlusion")
                         .setTooltip("If enabled, Fog Occlusion will be added to the vanilla menu so it can be toggled while in a world.")
                         .setControl(TickBoxControl::new)
-                        .setBinding((opts, value) -> opts.unofficial.showFogOcclusion = value, opts -> opts.unofficial.showFogOcclusion)
+                        .setBinding((opts, value) -> opts.speedrun.showFogOcclusion = value, opts -> opts.speedrun.showFogOcclusion)
                         .build()
                 )
                 .build());
-        return new OptionPage("Unofficial", ImmutableList.copyOf(groups));
+        return new OptionPage("Speedrun", ImmutableList.copyOf(groups));
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -47,6 +47,8 @@ public class SodiumGameOptions {
 
     public static class UnofficialSettings {
         public boolean usePlanarFog = false;
+        public boolean showEntityCulling = true;
+        public boolean showFogOcclusion = true;
     }
 
     public enum ChunkRendererBackendOption implements TextProvider {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -73,11 +73,7 @@ public class SodiumGameOptions {
             return this.supportedFunc.isSupported(disableBlacklist);
         }
 
-        public static class QualitySettings {
-        public boolean enableVignette = true;
-    }
-
-    public static ChunkRendererBackendOption[] getAvailableOptions(boolean disableBlacklist) {
+        public static ChunkRendererBackendOption[] getAvailableOptions(boolean disableBlacklist) {
             return streamAvailableOptions(disableBlacklist)
                     .toArray(ChunkRendererBackendOption[]::new);
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 public class SodiumGameOptions {
     public final QualitySettings quality = new QualitySettings();
     public final AdvancedSettings advanced = new AdvancedSettings();
-    public final UnofficialSettings unofficial = new UnofficialSettings();
+    public final SpeedrunSettings speedrun = new SpeedrunSettings();
 
     private File file;
 
@@ -45,8 +45,8 @@ public class SodiumGameOptions {
         public boolean enableVignette = true;
     }
 
-    public static class UnofficialSettings {
-        public boolean usePlanarFog = false;
+    public static class SpeedrunSettings {
+        public boolean usePlanarFog = true;
         public boolean showEntityCulling = true;
         public boolean showFogOcclusion = true;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/VanillaOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/VanillaOptions.java
@@ -1,7 +1,7 @@
 package me.jellysquid.mods.sodium.client.gui;
 
 import me.jellysquid.mods.sodium.client.gui.vanilla.builders.CycleOptionBuilder;
-import me.jellysquid.mods.sodium.client.gui.vanilla.options.EntityCulling;
+import me.jellysquid.mods.sodium.client.gui.vanilla.options.BooleanCyclingOption;
 import net.minecraft.client.options.Option;
 
 import java.util.HashSet;
@@ -24,12 +24,21 @@ public class VanillaOptions {
         DOUBLE_OPTIONS_RUNNABLE.add(apply);
     }
 
-    public static final Option ENTITY_CULLING = new CycleOptionBuilder<EntityCulling>()
+    public static final Option ENTITY_CULLING = new CycleOptionBuilder<BooleanCyclingOption>()
             .setKey("options.entityCulling")
             .setText("Entity Culling")
-            .setOptions(EntityCulling.values())
-            .setGetter((options) -> EntityCulling.getOption(options.advanced.useEntityCulling))
+            .setOptions(BooleanCyclingOption.values())
+            .setGetter((options) -> BooleanCyclingOption.getOption(options.advanced.useEntityCulling))
             .setSetter((options, value) -> options.advanced.useEntityCulling = value.isEnabled())
-            .setTextGetter(EntityCulling::getText)
+            .setTextGetter(BooleanCyclingOption::getText)
+            .build();
+
+    public static final Option FOG_OCCLUSION = new CycleOptionBuilder<BooleanCyclingOption>()
+            .setKey("options.fogOcclusion")
+            .setText("Fog Occlusion")
+            .setOptions(BooleanCyclingOption.values())
+            .setGetter(options -> BooleanCyclingOption.getOption(options.advanced.useFogOcclusion))
+            .setSetter((options, value) -> options.advanced.useFogOcclusion = value.isEnabled())
+            .setTextGetter(BooleanCyclingOption::getText)
             .build();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/vanilla/options/BooleanCyclingOption.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/vanilla/options/BooleanCyclingOption.java
@@ -2,15 +2,15 @@ package me.jellysquid.mods.sodium.client.gui.vanilla.options;
 
 import net.minecraft.client.resource.language.I18n;
 
-public enum EntityCulling implements IndexedOption {
-
+public enum BooleanCyclingOption implements IndexedOption {
     ON(0, true, "options.on"),
     OFF(1, false, "options.off");
 
     private final int index;
     private final boolean enabled;
     private final String text;
-    EntityCulling(int index, boolean enabled, String translationKey){
+
+    BooleanCyclingOption(int index, boolean enabled, String translationKey) {
         this.index = index;
         this.enabled = enabled;
         this.text = I18n.translate(translationKey);
@@ -29,8 +29,8 @@ public enum EntityCulling implements IndexedOption {
         return text;
     }
 
-    public static EntityCulling getOption(boolean value){
-        if(value){
+    public static BooleanCyclingOption getOption(boolean value) {
+        if (value) {
             return ON;
         }
         return OFF;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -308,7 +308,7 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
 
             if (dist != 0.0f) {
                 this.useFogCulling = true;
-                if (SodiumClientMod.options().unofficial.usePlanarFog) {
+                if (SodiumClientMod.options().speedrun.usePlanarFog) {
                     this.usePlanarFog = true;
                 }
                 this.fogRenderCutoff = Math.max(FOG_PLANE_MIN_DISTANCE, dist * dist);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkFogMode.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkFogMode.java
@@ -41,7 +41,7 @@ public enum ChunkFogMode {
 
         int mode = GL11.glGetInteger(GL11.GL_FOG_MODE);
 
-        boolean usePlanarFog = SodiumClientMod.options().unofficial.usePlanarFog;
+        boolean usePlanarFog = SodiumClientMod.options().speedrun.usePlanarFog;
 
         switch (mode) {
             case GL11.GL_EXP2:

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinBackgroundRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinBackgroundRenderer.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public abstract class MixinBackgroundRenderer {
     @Redirect(method = "applyFog", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setupNvFogDistance()V"))
     private static void redirectSetupNvFogDistance() {
-        if (SodiumClientMod.options().unofficial.usePlanarFog) {
+        if (SodiumClientMod.options().speedrun.usePlanarFog) {
             return;
         } else {
             RenderSystem.setupNvFogDistance();

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.sodium.mixin.features.options;
 
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
 import me.jellysquid.mods.sodium.client.gui.VanillaOptions;
 import me.jellysquid.mods.sodium.client.gui.options.OptionFlag;
@@ -15,12 +16,14 @@ import net.minecraft.client.options.Option;
 import net.minecraft.text.Text;
 import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 @Mixin(VideoOptionsScreen.class)
@@ -30,28 +33,17 @@ public class MixinVideoOptionsScreen extends GameOptionsScreen {
         super(parent, gameOptions, title);
     }
 
-    private static final Option[] OPTIONS = {
-            Option.GRAPHICS,
-            Option.RENDER_DISTANCE,
-            Option.AO,
-            Option.FRAMERATE_LIMIT,
-            Option.VSYNC,
-            Option.VIEW_BOBBING,
-            Option.GUI_SCALE,
-            Option.ATTACK_INDICATOR,
-            Option.GAMMA,
-            Option.CLOUDS,
-            Option.FULLSCREEN,
-            Option.PARTICLES,
-            Option.MIPMAP_LEVELS,
-            Option.ENTITY_SHADOWS,
-            VanillaOptions.ENTITY_CULLING,
-            VanillaOptions.FOG_OCCLUSION
-    };
-
     @Redirect(method = "init", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonListWidget;addAll([Lnet/minecraft/client/options/Option;)V"))
-    private void optionsSwap(ButtonListWidget list, Option[] old_options){
-        list.addAll(OPTIONS);
+    private void optionsSwap(ButtonListWidget list, Option[] old_options) {
+        List<Option> options =  new ArrayList<>(Arrays.asList(old_options));
+        SodiumGameOptions.UnofficialSettings speedrunSettings = SodiumClientMod.options().unofficial;
+        if (speedrunSettings.showEntityCulling) {
+            options.add(VanillaOptions.ENTITY_CULLING);
+        }
+        if (speedrunSettings.showFogOcclusion) {
+            options.add(VanillaOptions.FOG_OCCLUSION);
+        }
+        list.addAll(options.toArray(new Option[0]));
     }
 
     @Inject(method = "mouseReleased", at = @At("RETURN"))

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
@@ -45,7 +45,8 @@ public class MixinVideoOptionsScreen extends GameOptionsScreen {
             Option.PARTICLES,
             Option.MIPMAP_LEVELS,
             Option.ENTITY_SHADOWS,
-            VanillaOptions.ENTITY_CULLING
+            VanillaOptions.ENTITY_CULLING,
+            VanillaOptions.FOG_OCCLUSION
     };
 
     @Redirect(method = "init", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonListWidget;addAll([Lnet/minecraft/client/options/Option;)V"))

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
@@ -51,7 +51,6 @@ public class MixinVideoOptionsScreen extends GameOptionsScreen {
     @Redirect(method = "init", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonListWidget;addAll([Lnet/minecraft/client/options/Option;)V"))
     private void optionsSwap(ButtonListWidget list, Option[] old_options){
         list.addAll(OPTIONS);
-        VanillaOptions.clearSettingsChanges();
     }
 
     @Inject(method = "mouseReleased", at = @At("RETURN"))

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/options/MixinVideoOptionsScreen.java
@@ -36,7 +36,7 @@ public class MixinVideoOptionsScreen extends GameOptionsScreen {
     @Redirect(method = "init", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonListWidget;addAll([Lnet/minecraft/client/options/Option;)V"))
     private void optionsSwap(ButtonListWidget list, Option[] old_options) {
         List<Option> options =  new ArrayList<>(Arrays.asList(old_options));
-        SodiumGameOptions.UnofficialSettings speedrunSettings = SodiumClientMod.options().unofficial;
+        SodiumGameOptions.SpeedrunSettings speedrunSettings = SodiumClientMod.options().speedrun;
         if (speedrunSettings.showEntityCulling) {
             options.add(VanillaOptions.ENTITY_CULLING);
         }


### PR DESCRIPTION
changes
\- add fog occlusion to vanilla video options screen
\- make the addition of entity culling and fog occlusion options to the vanilla video options screen individually optional
\- rename unofficial tab to speedrun and make planar fog default to match 1.16.1

fixes
\- queued setting change is cleared if slider is still held down when fullscreen (re-init)