### PR TITLE
Set capacity of WorldRenderer#visibleChunks list to 0

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
@@ -17,6 +17,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
@@ -37,6 +38,12 @@ public abstract class MixinWorldRenderer implements WorldRendererExtended {
     @Override
     public SodiumWorldRenderer getSodiumWorldRenderer() {
         return renderer;
+    }
+
+    @ModifyArg(method = "<init>", at = @At(value = "INVOKE", target = "Lit/unimi/dsi/fastutil/objects/ObjectArrayList;<init>(I)V"))
+    private int nullifyVisibleChunksList(int capacity) {
+        // Sodium doesn't use this list, so we prevent the initial capacity of 69696 to be allocated
+        return 0;
     }
 
     @Redirect(method = "reload", at = @At(value = "FIELD", target = "Lnet/minecraft/client/options/GameOptions;viewDistance:I", ordinal = 1))


### PR DESCRIPTION
Vanilla initializes its visibleChunks list with a capacity of 69696, with SeedQueues WorldRenderers for the wall screen that can add up to multiple megabytes of completely unused memory