### PR TITLE
Added render threads option

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -39,8 +39,8 @@ public class SodiumGameOptions implements SpeedrunConfig {
         public boolean showEntityCulling = true;
         public boolean showFogOcclusion = true;
 
-        @Config.Numbers.Whole.Bounds(min = 1, max = 32)
-        public int renderThreads = 1;
+        @Config.Numbers.Whole.Bounds(min = 0, max = 32)
+        public int renderThreads = 0;
     }
 
     {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -38,6 +38,9 @@ public class SodiumGameOptions implements SpeedrunConfig {
         public boolean usePlanarFog = true;
         public boolean showEntityCulling = true;
         public boolean showFogOcclusion = true;
+
+        @Config.Numbers.Whole.Bounds(min = 1, max = 32)
+        public int renderThreads = 1;
     }
 
     {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -19,6 +19,8 @@ public class SodiumGameOptions implements SpeedrunConfig {
     public final SpeedrunSettings speedrun = new SpeedrunSettings();
 
     public static class AdvancedSettings implements SpeedrunConfigStorage {
+        @Config.Numbers.Whole.Bounds(min = 0, max = 32)
+        public int chunkUpdateThreads = 0;
         public boolean useChunkMultidraw = true;
         public boolean useBlockFaceCulling = true;
         public boolean useCompactVertexFormat = true;
@@ -38,9 +40,6 @@ public class SodiumGameOptions implements SpeedrunConfig {
         public boolean usePlanarFog = true;
         public boolean showEntityCulling = true;
         public boolean showFogOcclusion = true;
-
-        @Config.Numbers.Whole.Bounds(min = 0, max = 32)
-        public int renderThreads = 0;
     }
 
     {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
@@ -71,7 +71,7 @@ public class ChunkBuilder<T extends ChunkGraphicsState> {
     }
 
     private static int getThreadCount() {
-        int requested = SodiumClientMod.options().speedrun.renderThreads;
+        int requested = SodiumClientMod.options().advanced.chunkUpdateThreads;
         return requested == 0 ? getOptimalThreadCount() : Math.min(requested, getMaxThreadCount());
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile;
 
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
 import me.jellysquid.mods.sodium.client.model.vertex.type.ChunkVertexType;
 import me.jellysquid.mods.sodium.client.render.chunk.ChunkGraphicsState;
@@ -57,7 +58,7 @@ public class ChunkBuilder<T extends ChunkGraphicsState> {
     public ChunkBuilder(ChunkVertexType vertexType, ChunkRenderBackend<T> backend) {
         this.vertexType = vertexType;
         this.backend = backend;
-        this.limitThreads = getOptimalThreadCount();
+        this.limitThreads = SodiumClientMod.options().speedrun.renderThreads;
     }
 
     /**

--- a/src/main/resources/assets/sodium/lang/en_us.json
+++ b/src/main/resources/assets/sodium/lang/en_us.json
@@ -29,5 +29,7 @@
     "speedrunapi.config.sodium.option.speedrun:showEntityCulling": "Show Entity Culling",
     "speedrunapi.config.sodium.option.speedrun:showEntityCulling.description": "If enabled, Entity Culling will be added to the vanilla menu so it can be toggled while in a world.",
     "speedrunapi.config.sodium.option.speedrun:showFogOcclusion": "Show Fog Occlusion",
-    "speedrunapi.config.sodium.option.speedrun:showFogOcclusion.description": "If enabled, Fog Occlusion will be added to the vanilla menu so it can be toggled while in a world."
+    "speedrunapi.config.sodium.option.speedrun:showFogOcclusion.description": "If enabled, Fog Occlusion will be added to the vanilla menu so it can be toggled while in a world.",
+    "speedrunapi.config.sodium.option.speedrun:renderThreads": "Render Threads",
+    "speedrunapi.config.sodium.option.speedrun:renderThreads.description": "How many render threads to create (lower = less F3+F lag)"
 }

--- a/src/main/resources/assets/sodium/lang/en_us.json
+++ b/src/main/resources/assets/sodium/lang/en_us.json
@@ -31,5 +31,6 @@
     "speedrunapi.config.sodium.option.speedrun:showFogOcclusion": "Show Fog Occlusion",
     "speedrunapi.config.sodium.option.speedrun:showFogOcclusion.description": "If enabled, Fog Occlusion will be added to the vanilla menu so it can be toggled while in a world.",
     "speedrunapi.config.sodium.option.speedrun:renderThreads": "Render Threads",
-    "speedrunapi.config.sodium.option.speedrun:renderThreads.description": "How many render threads to create (lower = less F3+F lag)"
+    "speedrunapi.config.sodium.option.speedrun:renderThreads.description": "How many render threads to create (lower = less F3+F lag)",
+    "speedrunapi.config.sodium.option.speedrun:renderThreads.value.0": "Auto"
 }

--- a/src/main/resources/assets/sodium/lang/en_us.json
+++ b/src/main/resources/assets/sodium/lang/en_us.json
@@ -4,6 +4,9 @@
     "speedrunapi.config.sodium.category.speedrun": "Speedrun",
     "speedrunapi.config.sodium.option.quality:enableVignette": "Vignette",
     "speedrunapi.config.sodium.option.quality:enableVignette.description": "If enabled, a vignette effect will be rendered on the player's view. This is very unlikely to make a difference to frame rates unless you are fill-rate limited.",
+    "speedrunapi.config.sodium.option.advanced:chunkUpdateThreads": "Chunk Update Threads",
+    "speedrunapi.config.sodium.option.advanced:chunkUpdateThreads.description": "How many chunk update threads to create (lower = less F3+F lag)",
+    "speedrunapi.config.sodium.option.advanced:chunkUpdateThreads.value.0": "Auto",
     "speedrunapi.config.sodium.option.advanced:useChunkMultidraw": "Use Chunk Multi-Draw",
     "speedrunapi.config.sodium.option.advanced:useChunkMultidraw.description": "Multi-draw allows multiple chunks to be rendered with fewer draw calls, greatly reducing CPU overhead when rendering the world while also potentially allowing for more efficient GPU utilization. This optimization may cause issues with some graphics drivers, so you should try disabling it if you are experiencing glitches.",
     "speedrunapi.config.sodium.option.advanced:useVertexArrayObjects": "Use Vertex Array Objects",
@@ -29,8 +32,5 @@
     "speedrunapi.config.sodium.option.speedrun:showEntityCulling": "Show Entity Culling",
     "speedrunapi.config.sodium.option.speedrun:showEntityCulling.description": "If enabled, Entity Culling will be added to the vanilla menu so it can be toggled while in a world.",
     "speedrunapi.config.sodium.option.speedrun:showFogOcclusion": "Show Fog Occlusion",
-    "speedrunapi.config.sodium.option.speedrun:showFogOcclusion.description": "If enabled, Fog Occlusion will be added to the vanilla menu so it can be toggled while in a world.",
-    "speedrunapi.config.sodium.option.speedrun:renderThreads": "Render Threads",
-    "speedrunapi.config.sodium.option.speedrun:renderThreads.description": "How many render threads to create (lower = less F3+F lag)",
-    "speedrunapi.config.sodium.option.speedrun:renderThreads.value.0": "Auto"
+    "speedrunapi.config.sodium.option.speedrun:showFogOcclusion.description": "If enabled, Fog Occlusion will be added to the vanilla menu so it can be toggled while in a world."
 }


### PR DESCRIPTION
Each time ChunkBuilder.startWorkers() is called, which happens on each f3+f, a certain number of Chunk Render Task Executor threads are created. By default this is Runtime.getRuntime().availableProcessors(), which results in 32 render threads constantly being recreated for CPUs with 32 logical processors. Reducing this number to 1 significantly improves performance of F3+F, with no obvious impact on rendering performance. An option for 1-32 has been added to the settings, ~~but I suspect the default of 1 will be optimal for everyone.~~ Upstream logic for calculating default thread count has been added, users can choose to override