### PR TITLE
Fix: Attempt delayed thread creation as long-term viable f3f lag spike fix

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -467,6 +467,8 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
         if (!futures.isEmpty()) {
             this.backend.upload(RenderDevice.INSTANCE.createCommandList(), new FutureDequeDrain<>(futures));
         }
+
+        this.builder.maybeIncreaseThreadLimit();
     }
 
     public void markDirty() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -103,6 +103,7 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
         this.world = world;
 
         this.builder = new ChunkBuilder<>(backend.getVertexType(), this.backend);
+        this.builder.SetupWithRender(renderDistance); // Split out for compat...
         this.builder.init(world, renderPassManager);
 
         this.dirty = true;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
@@ -50,9 +50,9 @@ public class ChunkBuilder<T extends ChunkGraphicsState> {
     private World world;
     private BlockRenderPassManager renderPassManager;
 
-    private final int limitThreads;
-    private final int initialThreads;
-    private boolean hasThreadSpace = true;
+    private int limitThreads;
+    private int initialThreads;
+    private boolean hasThreadSpace = false;
     private int updates = 0;
 
     private final ChunkVertexType vertexType;
@@ -63,7 +63,15 @@ public class ChunkBuilder<T extends ChunkGraphicsState> {
         this.backend = backend;
         this.limitThreads = getOptimalThreadCount();
         // We assume nobody is running with 1 CPU, I guess.
-        this.initialThreads = Math.max(2, this.limitThreads / 6 /* Arbitrarily chosen :) */);
+        this.initialThreads = this.limitThreads;
+    }
+
+    public void SetupWithRender(int viewDistance) {
+        // Choose threads based on viewDistance.
+        final int maxThreads = getOptimalThreadCount();
+        this.limitThreads = maxThreads * Math.min(Math.max(viewDistance, 5), 32) / 32;
+        // We assume nobody is running with 1 CPU, I guess.
+        this.initialThreads = Math.max(2, this.limitThreads / 2 /* Arbitrarily chosen :) */);
 
         this.hasThreadSpace = this.limitThreads > this.initialThreads;
     }


### PR DESCRIPTION
See #37 

Ideally, I think some of the constant/arbitrary values here should be configurable. ~~I can do that later if it's agreed that this is a viable solution for the F3+F lag spikes.~~ I think we actually need a solution like this (at least with thread scaling) in order to ensure compat with categories that require high render distance (e.g. AA)

We do a very cursed update()-based runtime calculation to gradually create more render threads, up until the theoretical maximum (lcores). This ***(based on extremely preliminary testing)*** seems to have the upside seen in #36 of reducing/mostly eliminating the extreme lag spikes when using F3+F repeatedly, while also (theoretically, untested, but I don't see how this wouldn't be the case) removing the downside of slower chunk loading when not modifying render distance (e.g. while flying in AA).

Changes recommended (for myself or anyone else who picks this up, if this is agreed on as a viable route to take to fix this issue):
- Configurable hard thread limit as in #36 (default to lcores, though)
- Configurable initial threads
- Configurable (or, just better) thread creation scaling - this creates 1 thread per 60 updates; I think it should probably be more like 60-30-15-7 (logarithmically increasing, so that we quickly hit max threads - e.g. when 32rd is hit)
- ~~**Concept:** Pass information on render distance down into the ChunkBuilder, and change scaling / min / max threads based on render distance. (Note: This is based on my understanding that each ChunkBuilder has 1, and exactly 1, render distance - I'm not 100% certain of this, but it does seem to be the case)~~ **Note - I implemented this. Seems to lead to pretty decent behaviour in-game. ~~However, I checked again with Jojoe's PR, and it doesn't _seem_ like that PR is noticeably slower/faster than this one (with viewDistance cap). I think this implementation is better in theory, but it's hard to prove exactly.~~** Tested against Jojoe's PR, this is more performant for loading 32 rd.

**Current Issues with PR:**
- May have side effects with SeedQueue performance / configuration options
- Completely breaks SeedQueue (stops generating seeds) _this is probably because it breaks SeedQueue worker injection somehow?_
- The calculations are kind of mediocre, I think they could be tuned slightly for some improvement.
- We still have small amounts of lag with F3+F here and there (although vastly better than anything else I've tested in identical conditions)

**Miscellaneous Notes:**
- I ran [normal sodium] with VisualVM and was able to replicate 20+ second freezes with no apparent related behaviour in the GC. I think Windows might just hate our threads? I'm not sure. In any case, unless someone with an extremely deep knowledge of how JVM+GC+threads interacts pops up, I don't think it'll be possible to find a "true" root cause fix for this.
- Based on a frankly _absurd_ amount of debugging and profiling, I have been completely unable to find 1 culprit, despite the fact that we know the lag spikes are directly related to the number of threads we create (see doogile fix). I'm pretty sure (97% confidence) that this is just some weird GC behaviour that freezes us a ton when threads are in some unknown state. Therefore, this is really a suboptimal solution; ideally we would figure out how to manipulate the thread objects so that this doesn't occur. (Maybe reduce cycles..?)